### PR TITLE
build: Unify component version property names

### DIFF
--- a/bftools/pom.xml
+++ b/bftools/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats_plugins</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats_plugins.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats-tools</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats-tools.version}</version>
     </dependency>
 
 <!--    <dependency>

--- a/bftools/pom.xml
+++ b/bftools/pom.xml
@@ -39,27 +39,12 @@
       <artifactId>bio-formats-tools</artifactId>
       <version>${bio-formats-tools.version}</version>
     </dependency>
-
-<!--    <dependency>
-      <groupId>org.openmicroscopy</groupId>
-      <artifactId>lwf-stubs</artifactId>
-      <version>${lwf-stubs.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.openmicroscopy</groupId>
-      <artifactId>mipav-stubs</artifactId>
-      <version>${mipav-stubs.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId>
       <version>${imagej1.version}</version>
       <scope>provided</scope>
-    </dependency> -->
+    </dependency>
   </dependencies>
 
   <properties>

--- a/bio-formats-package/pom.xml
+++ b/bio-formats-package/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats_plugins</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats_plugins.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats-tools</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats-tools.version}</version>
     </dependency>
 
 <!--    <dependency>

--- a/bio-formats-package/pom.xml
+++ b/bio-formats-package/pom.xml
@@ -39,27 +39,6 @@
       <artifactId>bio-formats-tools</artifactId>
       <version>${bio-formats-tools.version}</version>
     </dependency>
-
-<!--    <dependency>
-      <groupId>org.openmicroscopy</groupId>
-      <artifactId>lwf-stubs</artifactId>
-      <version>${lwf-stubs.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.openmicroscopy</groupId>
-      <artifactId>mipav-stubs</artifactId>
-      <version>${mipav-stubs.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.imagej</groupId>
-      <artifactId>ij</artifactId>
-      <version>${imagej1.version}</version>
-      <scope>provided</scope>
-    </dependency> -->
   </dependencies>
 
   <properties>

--- a/loci-tools/pom.xml
+++ b/loci-tools/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats_plugins</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats_plugins.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bio-formats-tools</artifactId>
-      <version>${bio-formats.version}</version>
+      <version>${bio-formats-tools.version}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
     <date>${maven.build.timestamp}</date>
     <year>2018</year>
     <project.rootdir>${basedir}</project.rootdir>
-    <bio-formats.version>5.7.3</bio-formats.version>
+    <bioformats.version>5.7.3</bioformats.version>
+    <bio-formats_plugins.version>${bioformats.version}</bio-formats_plugins.version>
+    <bio-formats-tools.version>${bioformats.version}</bio-formats-tools.version>
     <imagej1.version>1.48s</imagej1.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j.version>1.7.6</slf4j.version>


### PR DESCRIPTION
This is to allow e.g. `-Dome-common.version=...` or rewriting the configuration to work the same for all components. 

Properties are named after the github repository name, with a compatibility name for the pom artifactId for compatibility with scijava.

Testing: check builds are green.