### PR TITLE
Sync changes for Bio-Formats 5.8.2

### DIFF
--- a/bftools/assembly.xml
+++ b/bftools/assembly.xml
@@ -10,7 +10,7 @@
   <dependencySets>
     <dependencySet>
       <outputDirectory>bftools-${project.version}/jar</outputDirectory>
-      <useProjectArtifact>true</useProjectArtifact>
+      <useProjectArtifact>false</useProjectArtifact>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/bftools/pom.xml
+++ b/bftools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>bio-formats-bundles</artifactId>
-    <version>5.7.4-SNAPSHOT</version>
+    <version>5.8.2</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/bio-formats-package/pom.xml
+++ b/bio-formats-package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>bio-formats-bundles</artifactId>
-    <version>5.7.4-SNAPSHOT</version>
+    <version>5.8.2</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/loci-tools/pom.xml
+++ b/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>bio-formats-bundles</artifactId>
-    <version>5.7.4-SNAPSHOT</version>
+    <version>5.8.2</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-bundles</artifactId>
-  <version>5.7.4-SNAPSHOT</version>
+  <version>5.8.2</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats bundle collection</name>
@@ -29,11 +29,11 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <release.version>5.7.3</release.version>
+    <release.version>5.8.2</release.version>
     <date>${maven.build.timestamp}</date>
     <year>2018</year>
     <project.rootdir>${basedir}</project.rootdir>
-    <bioformats.version>5.7.3</bioformats.version>
+    <bioformats.version>5.8.2</bioformats.version>
     <bio-formats_plugins.version>${bioformats.version}</bio-formats_plugins.version>
     <bio-formats-tools.version>${bioformats.version}</bio-formats-tools.version>
     <imagej1.version>1.52a</imagej1.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <bioformats.version>5.7.3</bioformats.version>
     <bio-formats_plugins.version>${bioformats.version}</bio-formats_plugins.version>
     <bio-formats-tools.version>${bioformats.version}</bio-formats-tools.version>
-    <imagej1.version>1.48s</imagej1.version>
+    <imagej1.version>1.52a</imagej1.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j.version>1.7.6</slf4j.version>
 


### PR DESCRIPTION
See [trello](https://trello.com/c/IaqwRcg6/22-update-repositories-for-582).

Same as https://github.com/ome/bio-formats-imagej/pull/3 with updates to the bioformats and imagej versions, plus a small assembly tweak to fix a warning.

Testing: Check jobs are green.  Try `bftools` from `https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge/jdk=JDK9,label=testintegration/ws/bio-formats-build/bio-formats-bundles/bftools/target/`